### PR TITLE
Added address as second argument to eth.signTransaction. To fix #22

### DIFF
--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -312,8 +312,8 @@ var Eth = function Eth() {
         new Method({
             name: 'signTransaction',
             call: 'eth_signTransaction',
-            params: 1,
-            inputFormatter: [formatter.inputTransactionFormatter]
+            params: 2,
+            inputFormatter: [formatter.inputTransactionFormatter, formatter.inputAddressFormatter]
         }),
         new Method({
             name: 'sendTransaction',


### PR DESCRIPTION
In web3 1.0, eth.signTransaction method should take two mandatory arguments,  transaction and address. In current implementation it's expecting only "transaction" argument. 

This pull request adds a second argument of address type.

web3 1.0 Spec - https://web3js.readthedocs.io/en/1.0/web3-eth.html#signtransaction

To fix #22 
