### PR TITLE
Fixed top-level package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Some example uses cases are available in the project [wiki](https://github.com/a
     &nbsp;&nbsp;&nbsp;&nbsp;Run `npm run browserify` to produce `dist/web3.min.js` and include it in your html file
 * Node use: 
     ```
-    var Web3 = require('aion-web3-core')
+    var Web3 = require('aion-web3')
     var web3 = new Web3(new Web3.providers.HttpProvider("http://localhost:8545"));
     ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install
 or
 
 ```bash
-npm install --save aion-web3-core
+npm install --save aion-web3
 ```
 
 ## API Use


### PR DESCRIPTION
Hello. One should install `aion-web3` as root package, not `aion-web3-core`. I've spent almost whole day to realize why the `Web3.providers` is `undefined`.