### PR TITLE
Expose txRsp errorData

### DIFF
--- a/packages/web3-core-helpers/src/errors.js
+++ b/packages/web3-core-helpers/src/errors.js
@@ -28,6 +28,8 @@
 module.exports = {
     ErrorResponse: function (result) {
         var message = !!result && !!result.error && !!result.error.message ? result.error.message : JSON.stringify(result);
+        if (result && result.error && result.error.data)
+            message += "..." + result.error.data;
         return new Error('Returned error: ' + message);
     },
     InvalidNumberOfParams: function (got, expected, method) {


### PR DESCRIPTION
The ApiServer was recently upgraded to provide more meaningful error messages in response to the sendTransaction and sendRawTransaction requests.

The client side needs a minor upgrade to express these error messages, which is implemented in this PR. Note that this change also exposes other error messages that we are currently sending from server to client, but are not printing.