### PR TITLE
fix browserify npm script

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var Web3 = require('./lib/web3');
+var Web3 = require('./packages/web3');
 
 // dont override global variable
 if (typeof window !== 'undefined' && typeof window.Web3 === 'undefined') {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "lerna bootstrap",
     "docs": "cd docs; make html;",
     "lint": "jshint *.js packages",
-    "browserify": "mkdir ./dist && browserify index.js -o dist/web3.min.js",
+    "browserify": "mkdir -p ./dist && browserify index.js -o dist/web3.min.js",
     "test": "jshint *.js packages; mocha --opts mocha.opt",
     "integ-test": "mocha --opts mocha.opt -t 50000 integ_test/*.js --exclude _integ_test_config.js",
     "coverage": "nyc mocha || true",


### PR DESCRIPTION
Fix the `browserify` npm script.  The 'starting point' js file was `require`ing the wrong file.  Also previously the script failed if the dist directory already existed.

Testing:

- Ran browserify npm task
```
sergiu@aion-XPS-8930:~/repos/aion_web3$ npm run browserify

> aion-web3@1.0.0 browserify /home/sergiu/repos/aion_web3
> mkdir -p ./dist && browserify index.js -o dist/web3.min.js
```

- Then made a simple HTML file that uses the web3.min.js that browserify produces; turned on CORS requests in kernel; saw that HTML file can get hash rate correctly 