### PR TITLE
Remove the web3.eth.subscribe functionality

### DIFF
--- a/packages/web3-eth/src/index.js
+++ b/packages/web3-eth/src/index.js
@@ -27,7 +27,6 @@
 var _ = require('underscore');
 var core = require('aion-web3-core');
 var helpers = require('aion-web3-core-helpers');
-var Subscriptions = require('aion-web3-core-subscriptions').subscriptions;
 var Method = require('aion-web3-core-method');
 var utils = require('aion-web3-utils');
 var Net = require('aion-web3-net');
@@ -114,9 +113,6 @@ var Eth = function Eth() {
         },
         enumerable: true
     });
-
-
-    this.clearSubscriptions = _this._requestManager.clearSubscriptions;
 
     // add net
     this.net = new Net(this.currentProvider);
@@ -336,86 +332,6 @@ var Eth = function Eth() {
             name: 'compileSolidity',
             call: 'eth_compileSolidity',
             params: 1
-        }),
-
-        // subscriptions
-        new Subscriptions({
-            name: 'subscribe',
-            type: 'eth',
-            subscriptions: {
-                'newBlockHeaders': {
-                    // TODO rename on RPC side?
-                    subscriptionName: 'newHeads', // replace subscription with this name
-                    params: 0,
-                    outputFormatter: formatter.outputBlockFormatter
-                },
-                'pendingTransactions': {
-                    subscriptionName: 'newPendingTransactions', // replace subscription with this name
-                    params: 0
-                },
-                'logs': {
-                    params: 1,
-                    inputFormatter: [formatter.inputLogFormatter],
-                    outputFormatter: formatter.outputLogFormatter,
-                    // DUBLICATE, also in web3-eth-contract
-                    subscriptionHandler: function (output) {
-                        if(output.removed) {
-                            this.emit('changed', output);
-                        } else {
-                            this.emit('data', output);
-                        }
-
-                        if (_.isFunction(this.callback)) {
-                            this.callback(null, output, this);
-                        }
-                    }
-                },
-                'syncing': {
-                    params: 0,
-                    outputFormatter: formatter.outputSyncingFormatter,
-                    subscriptionHandler: function (output) {
-                        var _this = this;
-
-                        // fire TRUE at start
-                        if(this._isSyncing !== true) {
-                            this._isSyncing = true;
-                            this.emit('changed', _this._isSyncing);
-
-                            if (_.isFunction(this.callback)) {
-                                this.callback(null, _this._isSyncing, this);
-                            }
-
-                            setTimeout(function () {
-                                _this.emit('data', output);
-
-                                if (_.isFunction(_this.callback)) {
-                                    _this.callback(null, output, _this);
-                                }
-                            }, 0);
-
-                            // fire sync status
-                        } else {
-                            this.emit('data', output);
-                            if (_.isFunction(_this.callback)) {
-                                this.callback(null, output, this);
-                            }
-
-                            // wait for some time before fireing the FALSE
-                            clearTimeout(this._isSyncingTimeout);
-                            this._isSyncingTimeout = setTimeout(function () {
-                                if(output.currentBlock > output.highestBlock - 200) {
-                                    _this._isSyncing = false;
-                                    _this.emit('changed', _this._isSyncing);
-
-                                    if (_.isFunction(_this.callback)) {
-                                        _this.callback(null, _this._isSyncing, _this);
-                                    }
-                                }
-                            }, 500);
-                        }
-                    }
-                }
-            }
         })
     ];
 

--- a/test/eth_methods.js
+++ b/test/eth_methods.js
@@ -17,7 +17,6 @@ describe('eth', function() {
         u.methodExists(eth, 'getBlock');
         u.methodExists(eth, 'getTransaction');
         u.methodExists(eth, 'getBlockTransactionCount');
-        u.methodExists(eth, 'subscribe');
         u.methodExists(eth, 'Contract');
 
         u.methodExists(eth, 'isMining');


### PR DESCRIPTION
We currently do not support Ethereum's [subscribe](https://web3js.readthedocs.io/en/1.0/web3-eth-subscribe.html) functionality, but we still allow clients to send us subscribe requests. This is causing users to wonder what they're doing wrong (when the truth is that we simply don't support the feature yet).

This PR removes the public interface for the subscribe functionality. All tests pass, and I manually confirmed that it doesn't break basic Web3 functionality. 