### PR TITLE
remove endpoint url from console prompt

### DIFF
--- a/console.js
+++ b/console.js
@@ -8,6 +8,7 @@ try {
     const myURL = url.parse(process.argv[2]);
     if(myURL.protocol == 'https:' || myURL.protocol == 'http:') {
       endpoint = process.argv[2];
+    console.log('Connected to', endpoint);
     } else {
       throw 'Invalid address, make sure your node address follow the format "protocol://host:port"(e.g. https://aion.node:8545). Supported protocols: http, https';
     }
@@ -16,7 +17,7 @@ try {
     console.log('Connected to default', endpoint);
   }
 
-  var context = repl.start(endpoint +'> ').context;
+  var context = repl.start('> ').context;
   context.web3 = new Web3(new Web3.providers.HttpProvider(endpoint));
   context.eth = context.web3.eth;
   context.personal = context.web3.personal;

--- a/console.js
+++ b/console.js
@@ -5,7 +5,7 @@ var Web3 = require('./packages/web3');
 
 try {
   if (process.argv[2]) {
-    var promptPrefix;
+    let promptPrefix;
     const myURL = url.parse(process.argv[2]);
     if(myURL.protocol == 'https:' || myURL.protocol == 'http:') {
       endpoint = process.argv[2];

--- a/console.js
+++ b/console.js
@@ -5,19 +5,22 @@ var Web3 = require('./packages/web3');
 
 try {
   if (process.argv[2]) {
+    var promptPrefix;
     const myURL = url.parse(process.argv[2]);
     if(myURL.protocol == 'https:' || myURL.protocol == 'http:') {
       endpoint = process.argv[2];
-    console.log('Connected to', endpoint);
+      console.log('Connected to', endpoint);
+      promptPrefix = myURL.host;
     } else {
       throw 'Invalid address, make sure your node address follow the format "protocol://host:port"(e.g. https://aion.node:8545). Supported protocols: http, https';
     }
   } else {
     endpoint = 'http://127.0.0.1:8545';
     console.log('Connected to default', endpoint);
+    promptPrefix = endpoint;
   }
 
-  var context = repl.start('> ').context;
+  var context = repl.start(promptPrefix + '> ').context;
   context.web3 = new Web3(new Web3.providers.HttpProvider(endpoint));
   context.eth = context.web3.eth;
   context.personal = context.web3.personal;


### PR DESCRIPTION
Currently the console prompt for web3 contains the endpoint, so localhost looks like

`127.0.0.1:8454>`

That looks reasonable, but when using a hosted node, the endpoint is really long and contains an API key, and the prompt ends up looking like

`https://api.nodesmith.io/v1/aion/testnet/jsonrpc?apiKey=secretApiKeyWhichShouldBePrivate123>`

Which just looks awkward and also people probably don't need to have their API key printed out on every line.  So in this PR I just change the prompt to always be `>`.  When the script is first executed, it will print out the endpoint it "connects" to.