### PR TITLE
Make utils.isAddress more strict (must start with a0 unless known special address)

### DIFF
--- a/integ_test/send_raw_transaction.js
+++ b/integ_test/send_raw_transaction.js
@@ -52,7 +52,7 @@ describe('send raw transaction of 0.01337 aions and no data', () => {
             done(err);
           }
 
-          res.value.should.eql(tx.value.toString());
+          client.utils.toHex(res.value).should.eql(tx.value);
           res.from.toLowerCase().should.eql(opts.from.toLowerCase());
           res.to.toLowerCase().should.eql(tx.to.toLowerCase());
           done();

--- a/packages/aion-lib/src/accounts.js
+++ b/packages/aion-lib/src/accounts.js
@@ -11,6 +11,24 @@ let {
   toBuffer
 } = require('./formats')
 
+let validNonA0PrefixAddresses = [
+	"0000000000000000000000000000000000000000000000000000000000000200",
+	"08efa07244bacb5dc92daef46474560b57e9cfc2be62072fa21decf64051a317",
+	"0a0b61014dc764640ee6087095faf68dfeb4e4b9ee681225611fea65932c93e4",
+	"1318abaea6686c79eaa4ba37f5eef843bd065e74560ed1094133641b4f2395b8",
+	"24a970ec53022623d95989e3340ff180a843c8645841699c4c19a227287901cf",
+	"38dd1ae75523611bed9d4b647016dc8b0735c42317bd03e9bd65ceca69e8c46c",
+	"64b09d162e2f91d3308381f28c02b9d0e5cb4270a43465b696e1db6210aad189",
+	"7b8289c4b1ada70af8794b508f6db000ca25f1d1821c053da302a0403f73b29e",
+	"aebf26d4d5438304e277a3d5104a3b056d8617f586f33560d4b2e7984a2bfe01",
+	"af504da64d6cb7ec06a462b2c43a3cb4e482db3b41fde42b537f4c64fedc894b",
+	"af694e98b964b275d723c2c66e224739d97d36125bba985215bca1075656b82e",
+	"c00dcc9fe51c73767fad07cd4da990a8aa7487f40ba5718f711b4fdc09ae5b6e",
+	"cb68ed818e6f712b315d53e0cce541b2d2e4c0d101ef1fcc91bccef1c21dffd7",
+	"d801109bab93a4ab71c16e85389d9c366a23a975693cbdcc7e6db85561f1d5ce",
+	"f5079727f0c503b5eae232dbd303128338576fc1db867892ae07dcc920691ab9"
+];
+
 // address + message signature length
 let aionPubSigLen = nacl.sign.publicKeyLength + nacl.sign.signatureLength
 
@@ -70,7 +88,8 @@ function isAccountAddress(val) {
     return false
   }
 
-  return patterns.address.test(val) === true
+  return patterns.address.test(val) === true || 
+      (patterns.hash.test(val) && validNonA0PrefixAddresses.indexOf(val.replace(/^0x/, "")) > 0)
 }
 
 function bit(arr, index) {

--- a/packages/aion-lib/src/patterns.js
+++ b/packages/aion-lib/src/patterns.js
@@ -8,10 +8,9 @@ let patterns = Object.freeze({
   hex: /^(-0x|0x)?[0-9a-f]{1,}$/i,
   // positive or negative hex with 0x
   hexStrict: /^(-)?0x[0-9a-f]{1,}$/i,
-  // aion-specific 0x0a
-  // 0xa0 some addresses arent 0xa0 yet
-  // address: /^(0x)?a0[0-9a-f]{62}$/i,
-  address: /^(0x)?[0-9a-f]{64}$/i,
+  // address begins with a0 (for special addresses that don't, use separate whitelist)
+  address: /^(0x)?a0[0-9a-f]{62}$/i,
+  hash: /^(0x)?[0-9a-f]{64}$/i,
   // starts with utf8 null characters
   utf8Null: /^(?:\u0000)*/, // eslint-disable-line no-control-regex
   // matches solidity array types int128[64] or uint128[32]

--- a/test/batch.js
+++ b/test/batch.js
@@ -33,14 +33,14 @@ describe('lib/web3/batch', function () {
                 var second = payload[1];
 
                 assert.equal(first.method, 'eth_getBalance');
-                assert.deepEqual(first.params, ['0x0000000000000000000000000000000000000000000000000000000000000000', 'latest']);
+                assert.deepEqual(first.params, ['0xa000000000000000000000000000000000000000000000000000000000000000', 'latest']);
                 assert.equal(second.method, 'eth_getBalance');
-                assert.deepEqual(second.params, ['0x0000000000000000000000000000000000000000000000000000000000000005', 'latest']);
+                assert.deepEqual(second.params, ['0xa000000000000000000000000000000000000000000000000000000000000005', 'latest']);
             });
 
             var batch = new web3.BatchRequest();
-            batch.add(web3.eth.getBalance.request('0x0000000000000000000000000000000000000000000000000000000000000000', 'latest', callback));
-            batch.add(web3.eth.getBalance.request('0x0000000000000000000000000000000000000000000000000000000000000005', 'latest', callback2));
+            batch.add(web3.eth.getBalance.request('0xa000000000000000000000000000000000000000000000000000000000000000', 'latest', callback));
+            batch.add(web3.eth.getBalance.request('0xa000000000000000000000000000000000000000000000000000000000000005', 'latest', callback2));
             batch.execute();
         });
 
@@ -92,7 +92,7 @@ describe('lib/web3/batch', function () {
             }];
 
 
-            var address = '0x1000000000000000000000000000000000000000000000000000000000000001';
+            var address = '0xa000000000000000000000000000000000000000000000000000000000000001';
             var result = '0x126';
             var resultVal = '294';
             var result2 = '0x00000000000000000000000000000123';
@@ -120,48 +120,48 @@ describe('lib/web3/batch', function () {
 
 
                 assert.equal(payload[0].method, 'eth_getBalance');
-                assert.deepEqual(payload[0].params, ['0x0000000000000000000000000000000000000000000000000000000000000022', 'latest']);
+                assert.deepEqual(payload[0].params, ['0xa000000000000000000000000000000000000000000000000000000000000022', 'latest']);
 
                 assert.equal(payload[1].method, 'eth_call');
                 assert.deepEqual(payload[1].params, [{
-                    'to': '0x1000000000000000000000000000000000000000000000000000000000000001',
-                    'data': '0xe3d670d71000000000000000000000000000000000000000000000000000000000000001'
+                    'to': '0xa000000000000000000000000000000000000000000000000000000000000001',
+                    'data': '0xe3d670d7a000000000000000000000000000000000000000000000000000000000000001'
                 },
                     'latest' // default block
                 ]);
 
                 assert.equal(payload[2].method, 'eth_call');
                 assert.deepEqual(payload[2].params, [{
-                    'to': '0x1000000000000000000000000000000000000000000000000000000000000001',
-                    'from': '0x1000000000000000000000000000000000000000000000000000000000000002',
-                    'data': '0xe3d670d71000000000000000000000000000000000000000000000000000000000000001'
+                    'to': '0xa000000000000000000000000000000000000000000000000000000000000001',
+                    'from': '0xa000000000000000000000000000000000000000000000000000000000000002',
+                    'data': '0xe3d670d7a000000000000000000000000000000000000000000000000000000000000001'
                 },
                     'latest' // default block
                 ]);
 
                 assert.equal(payload[3].method, 'eth_call');
                 assert.deepEqual(payload[3].params, [{
-                    'to': '0x1000000000000000000000000000000000000000000000000000000000000001',
-                    'from': '0x1000000000000000000000000000000000000000000000000000000000000003',
-                    'data': '0xe3d670d71000000000000000000000000000000000000000000000000000000000000001'
+                    'to': '0xa000000000000000000000000000000000000000000000000000000000000001',
+                    'from': '0xa000000000000000000000000000000000000000000000000000000000000003',
+                    'data': '0xe3d670d7a000000000000000000000000000000000000000000000000000000000000001'
                 },
                     '0xa' // default block
                 ]);
 
                 assert.equal(payload[4].method, 'eth_call');
                 assert.deepEqual(payload[4].params, [{
-                    'to': '0x1000000000000000000000000000000000000000000000000000000000000001',
-                    'data': '0xe3d670d71000000000000000000000000000000000000000000000000000000000000001'
+                    'to': '0xa000000000000000000000000000000000000000000000000000000000000001',
+                    'data': '0xe3d670d7a000000000000000000000000000000000000000000000000000000000000001'
                 },
                     '0xa' // default block
                 ]);
             });
 
             var batch = new web3.BatchRequest();
-            batch.add(web3.eth.getBalance.request('0x0000000000000000000000000000000000000000000000000000000000000022', 'latest', callback));
+            batch.add(web3.eth.getBalance.request('0xa000000000000000000000000000000000000000000000000000000000000022', 'latest', callback));
             batch.add(new web3.eth.Contract(abi, address).methods.balance(address).call.request(callback2));
-            batch.add(new web3.eth.Contract(abi, address).methods.balance(address).call.request({from: '0x1000000000000000000000000000000000000000000000000000000000000002'}, callback2));
-            batch.add(new web3.eth.Contract(abi, address).methods.balance(address).call.request({from: '0x1000000000000000000000000000000000000000000000000000000000000003'}, 10, callback2));
+            batch.add(new web3.eth.Contract(abi, address).methods.balance(address).call.request({from: '0xa000000000000000000000000000000000000000000000000000000000000002'}, callback2));
+            batch.add(new web3.eth.Contract(abi, address).methods.balance(address).call.request({from: '0xa000000000000000000000000000000000000000000000000000000000000003'}, 10, callback2));
             batch.add(new web3.eth.Contract(abi, address).methods.balance(address).call.request(10, callback3));
             provider.injectBatchResults([result, result2, result2, result2, result2]);
             batch.execute();
@@ -187,7 +187,7 @@ describe('lib/web3/batch', function () {
             }];
 
 
-            var address = '0x1000000000000000000000000000000000000000000000000000000000000001';
+            var address = '0xa000000000000000000000000000000000000000000000000000000000000001';
             var result = 'Something went wrong';
             var result2 = 'Something went wrong 2';
 
@@ -209,19 +209,19 @@ describe('lib/web3/batch', function () {
                 var second = payload[1];
 
                 assert.equal(first.method, 'eth_getBalance');
-                assert.deepEqual(first.params, ['0x0000000000000000000000000000000000000000000000000000000000000000', 'latest']);
+                assert.deepEqual(first.params, ['0xa000000000000000000000000000000000000000000000000000000000000000', 'latest']);
                 assert.equal(second.method, 'eth_call');
                 assert.deepEqual(second.params, [{
-                    'to': '0x1000000000000000000000000000000000000000000000000000000000000001',
-                    'from': '0x0000000000000000000000000000000000000000000000000000000000000000',
-                    'data': '0xe3d670d71000000000000000000000000000000000000000000000000000000000000001'
+                    'to': '0xa000000000000000000000000000000000000000000000000000000000000001',
+                    'from': '0xa000000000000000000000000000000000000000000000000000000000000000',
+                    'data': '0xe3d670d7a000000000000000000000000000000000000000000000000000000000000001'
                 },
                 '0xa']);
             });
 
             var batch = new web3.BatchRequest();
-            batch.add(web3.eth.getBalance.request('0x0000000000000000000000000000000000000000000000000000000000000000', 'latest', callback));
-            batch.add(new web3.eth.Contract(abi, address).methods.balance(address).call.request({from: '0x0000000000000000000000000000000000000000000000000000000000000000'}, 10, callback2));
+            batch.add(web3.eth.getBalance.request('0xa000000000000000000000000000000000000000000000000000000000000000', 'latest', callback));
+            batch.add(new web3.eth.Contract(abi, address).methods.balance(address).call.request({from: '0xa000000000000000000000000000000000000000000000000000000000000000'}, 10, callback2));
             provider.injectBatchResults([result, result2], true); // injects error
             batch.execute();
         });
@@ -241,7 +241,7 @@ describe('lib/web3/batch', function () {
                 }]
             }];
 
-            const address = '0x1000000000000000000000000000000000000000000000000000000000000001';
+            const address = '0xa000000000000000000000000000000000000000000000000000000000000001';
             const result = '0x00000000000000000000000000000123';
 
             const callback = (err, _r) => {
@@ -252,7 +252,7 @@ describe('lib/web3/batch', function () {
             provider.injectValidation((payload) => {
                 assert.equal(payload[0].method, 'eth_call');
                 assert.deepEqual(payload[0].params, [{
-                    to: '0x1000000000000000000000000000000000000000000000000000000000000001',
+                    to: '0xa000000000000000000000000000000000000000000000000000000000000001',
                     data: '0x95d89b41'
                 },
                 'latest']);
@@ -296,14 +296,14 @@ describe('lib/web3/batch', function () {
                 var second = payload[1];
 
                 assert.equal(first.method, 'eth_getBalance');
-                assert.deepEqual(first.params, ['0x0000000000000000000000000000000000000000000000000000000000000000', 'latest']);
+                assert.deepEqual(first.params, ['0xa000000000000000000000000000000000000000000000000000000000000000', 'latest']);
                 assert.equal(second.method, 'eth_getBalance');
-                assert.deepEqual(second.params, ['0x0000000000000000000000000000000000000000000000000000000000000005', 'latest']);
+                assert.deepEqual(second.params, ['0xa000000000000000000000000000000000000000000000000000000000000005', 'latest']);
             });
 
             var batch = new web3.BatchRequest();
-            batch.add(web3.eth.getBalance.request('0x0000000000000000000000000000000000000000000000000000000000000000', 'latest', callback));
-            batch.add(web3.eth.getBalance.request('0x0000000000000000000000000000000000000000000000000000000000000005', 'latest', callback2));
+            batch.add(web3.eth.getBalance.request('0xa000000000000000000000000000000000000000000000000000000000000000', 'latest', callback));
+            batch.add(web3.eth.getBalance.request('0xa000000000000000000000000000000000000000000000000000000000000005', 'latest', callback2));
             batch.execute();
         });
 

--- a/test/utils.isAddress.js
+++ b/test/utils.isAddress.js
@@ -16,7 +16,11 @@ var tests = [
     { value: '0xE247a45c287191d435A8a5D72A7C8dc030451E9F', is: false },
     { value: '0xe247a45c287191d435a8a5d72a7c8dc030451e9f', is: false },
     { value: '0xE247A45C287191D435A8A5D72A7C8DC030451E9F', is: false },
-    { value: '0XE247A45C287191D435A8A5D72A7C8DC030451E9F', is: false }
+    { value: '0XE247A45C287191D435A8A5D72A7C8DC030451E9F', is: false },
+    { value: '0xP06f640ced8bd31eb9e191887adde74888e9ca31fd8545dae3ae896773ccbc4f', is: false },
+    { value: '0x006f640ced8bd31eb9e191887adde74888e9ca31fd8545dae3ae896773ccbc4f', is: false },
+    { value: '0xc00dcc9fe51c73767fad07cd4da990a8aa7487f40ba5718f711b4fdc09ae5b6e', is: true},
+    { value: 'c00dcc9fe51c73767fad07cd4da990a8aa7487f40ba5718f711b4fdc09ae5b6e', is: true}
 ];
 
 accounts.forEach(function(item) {


### PR DESCRIPTION
utils.isAddress returns true if the input is any 64-character hex string.  

This PR makes it more strict -- addresses in Aion network begin with a0, aside from a list of accounts that were created before that rule was added.  Those account addresses are in a hard-coded white list.    The new logic is that isAddress returns true if the input is 64-character hex and either begins with a0 or is in the white list.

Unit tests pass; ran most of the integ tests, which pass (one of them was not run due to related issues with setting up kernel for it, but the tests that did run uses the `isAddress` logic).